### PR TITLE
Support Handlebars v2.0.0 and above

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,10 +1,12 @@
 var bookListingTemplate = require("./book-listing.handlebars");
 
-console.log(bookListingTemplate({
+var div = document.createElement('div');
+div.innerHTML = bookListingTemplate({
 	username: "test",
 	books: [
 		{ title: "A book", synopsis: "With a description" },
 		{ title: "Another book", synopsis: "From a very good author" },
 		{ title: "Book without synopsis" }
 	]
-}));
+});
+document.body.appendChild(div);

--- a/index.js
+++ b/index.js
@@ -6,11 +6,19 @@ var path = require("path");
 var fastreplace = require('./lib/fastreplace');
 var findNestedRequires = require('./lib/findNestedRequires');
 
+function versionCheck(hbCompiler, hbRuntime) {
+	return hbCompiler.COMPILER_REVISION === (hbRuntime["default"] || hbRuntime).COMPILER_REVISION;
+}
+
 module.exports = function(source) {
 	if (this.cacheable) this.cacheable();
 	var loaderApi = this;
 	var query = loaderUtils.parseQuery(this.query);
 	var runtimePath = query.runtime || require.resolve("handlebars/runtime");
+
+	if (!versionCheck(handlebars, require(runtimePath))) {
+		throw new Error('Handlebars compiler version does not match runtime version');
+	}
 
 	// Possible extensions for partials
 	var extensions = query.extensions;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "loader-utils": "0.2.x"
   },
   "peerDependencies": {
-    "handlebars": ">= 1.3.0 < 2"
+    "handlebars": ">= 1.3.0 < 3"
   },
   "licenses": [
     {


### PR DESCRIPTION
Retains support for Handlebars >=1.3

@kpdecker I looked through the Handlebars release notes and couldn't find any breaking changes to how this loader is using it.

This does add some support for detecting if the compiler version doesn't match the runtime, because the compiler output is different.

Resolves #18 