### PR TITLE
Use `files` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   },
   "homepage": "https://github.com/altano/handlebars-loader",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
Diff:
![image](https://cloud.githubusercontent.com/assets/1404810/7114787/2c5aa700-e1e1-11e4-82ab-f0daaf09b10c.png)

@altano Quick additional question, what's the syntax for defining additional `helperDirs`?

`loader: 'handlebars-loader?helperDirs[]=' + __dirname + '/assets/templates/helpers,' + process.env.helperDir` doesn't seem to work