### PR TITLE
Resolve helpers correctly if helperDirs and rootRelative both are set

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,9 +114,11 @@ module.exports = function(source) {
 			console.log("\nCompilation pass %d", ++compilationPass);
 		}
 
-		function referenceToRequest(ref) {
+		function referenceToRequest(ref, type) {
 			if (/^\$/.test(ref))
 				return ref.substring(1);
+			else if (type === 'helper' && query.helperDirs && query.helperDirs.length)
+				return ref;
 			else
 				return rootRelative + ref;
 		}
@@ -174,7 +176,7 @@ module.exports = function(source) {
 
 		var resolveUnclearStuffIterator = function(stuff, unclearStuffCallback) {
 			if (foundUnclearStuff[stuff]) return unclearStuffCallback();
-			var request = referenceToRequest(stuff.substr(1));
+			var request = referenceToRequest(stuff.substr(1), 'unclearStuff');
 			resolve(request, 'unclearStuff', function(err, result) {
 				if (!err && result) {
 					knownHelpers[stuff.substr(1)] = true;
@@ -188,7 +190,7 @@ module.exports = function(source) {
 
 		var resolvePartialsIterator = function(partial, partialCallback) {
 			if (foundPartials[partial]) return partialCallback();
-			var request = referenceToRequest(partial.substr(1));
+			var request = referenceToRequest(partial.substr(1), 'partial');
 
 			// Try every extension for partials
 			var i = 0;
@@ -212,7 +214,7 @@ module.exports = function(source) {
 
 		var resolveHelpersIterator = function(helper, helperCallback) {
 			if (foundHelpers[helper]) return helperCallback();
-			var request = referenceToRequest(helper.substr(1));
+			var request = referenceToRequest(helper.substr(1), 'helper');
 
 			resolve(request, 'helper', function(err, result) {
 				if (!err && result) {

--- a/test/relativeRoot/relative-partial.handlebars
+++ b/test/relativeRoot/relative-partial.handlebars
@@ -1,0 +1,3 @@
+{{#if description}}
+<p>{{description}}</p>
+{{/if}}

--- a/test/test.js
+++ b/test/test.js
@@ -246,4 +246,33 @@ describe('handlebars-loader', function () {
     });
   });
 
+  it('should find helpers and partials if both relativeRoot and helperDirs is set', function (done) {
+    var rootRelative = path.resolve(__dirname, 'relativeRoot') + '/';
+    var helperDirs = path.join(__dirname, 'helpers');
+    var stubs = {
+      'relative-partial': require('./relativeRoot/relative-partial.handlebars'),
+      'image': require('./helpers/image.js'),
+      'nested/quotify': require('./helpers/nested/quotify.js')
+    };
+    stubs[rootRelative + 'relative-partial'] = require('./relativeRoot/relative-partial.handlebars');
+
+    testTemplate(loader, './with-relative-root.handlebars', {
+      stubs: stubs,
+      query: '?helperDirs[]=' + helperDirs + '&rootRelative=' + rootRelative,
+      data: TEST_TEMPLATE_DATA
+    }, function (err, output, require) {
+      assert.ok(output, 'generated output');
+      assert.ok(require.calledWith('image'),
+        'should have loaded helper');
+
+      assert.ok(require.calledWith('nested/quotify'),
+        'should have loaded nested helper');
+
+      assert.ok(require.calledWith('relative-partial'),
+        'should have loaded partial with module syntax');
+      assert.ok(require.calledWith(rootRelative + 'relative-partial'),
+        'should have loaded partial with relative syntax');
+      done();
+    });
+  });
 });

--- a/test/with-relative-root-partials.handlebars
+++ b/test/with-relative-root-partials.handlebars
@@ -1,0 +1,5 @@
+{{image image}}
+
+{{>$relative-partial this}}
+
+{{>relative-partial this}}

--- a/test/with-relative-root.handlebars
+++ b/test/with-relative-root.handlebars
@@ -1,0 +1,9 @@
+{{image image}}
+
+{{./image image}}
+
+{{[nested/quotify] title}}
+
+{{>$relative-partial this}}
+
+{{>relative-partial this}}


### PR DESCRIPTION
Bug when both `helperDirs` and and absolute `rootRelative` params are specified, then the effect is that `helperDirs` is ignored.

When resolving the helper, it will get the absolute `rootRelative` path prepended if set. This makes sense for helpers with a path relative to `rootRelative`, but not when `helperDirs` is specifically set.
