### PR TITLE
Respect debug query option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(source) {
 		inlineRequires = new RegExp(inlineRequires);
 	}
 
-	var debug = false;
+	var debug = query.debug;
 
 	var hb = handlebars.create();
 	var JavaScriptCompiler = hb.JavaScriptCompiler;


### PR DESCRIPTION
This patch ensures the debug query option is picked up correctly, so we can use a config like the following in order to get debug output:

```js
{
    test: /\.hbs$/,
    loader: 'handlebars?debug=true'
}
```