### PR TITLE
Resolve partials and helpers correctly if inlineRequires is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function(source) {
 		};
 		MyJavaScriptCompiler.prototype.appendToBuffer = function (str) {
 			// This is a template (stringified HTML) chunk
-			if (str.indexOf('"') === 0) {
+			if (str.indexOf && str.indexOf('"') === 0) {
 				var replacements = findNestedRequires(str, inlineRequires);
 				str = fastreplace(str, replacements, function (match) {
 					return "\" + require(" + JSON.stringify(match) + ") + \"";

--- a/test/test.js
+++ b/test/test.js
@@ -316,4 +316,33 @@ describe('handlebars-loader', function () {
       done();
     });
   });
+
+  it('should find helpers and partials if inlineRequires is set', function (done) {
+    testTemplate(loader, './with-partials-helpers-inline-requires.handlebars', {
+      query: '?inlineRequires=^images\/',
+      stubs: {
+        './partial': require('./partial.handlebars'),
+        'partial': require('./partial.handlebars'),
+        'title': function (text) { return 'Title: ' + text; },
+        './description': function (text) { return 'Description: ' + text; },
+        './image': function (text) { return 'Image URL: ' + text; },
+        'images/path/to/image': 'http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50'
+      },
+      data: TEST_TEMPLATE_DATA
+    }, function (err, output, require) {
+      assert.ok(output, 'generated output');
+      assert.ok(require.calledWith('partial'),
+        'should have loaded partial with module syntax');
+      assert.ok(require.calledWith('./partial'),
+        'should have loaded partial with relative syntax');
+      assert.ok(require.calledWith('title'),
+        'should have loaded helper with module syntax');
+      assert.ok(require.calledWith('./description'),
+        'should have loaded helper with relative syntax');
+      assert.ok(require.calledWith('images/path/to/image'),
+        'should have required image path');
+      done();
+    });
+  });
+
 });

--- a/test/with-partials-helpers-inline-requires.handlebars
+++ b/test/with-partials-helpers-inline-requires.handlebars
@@ -1,0 +1,15 @@
+<h1>{{title}}</h1>
+
+{{! using module syntax }}
+{{>$partial this}}
+
+{{! using relative syntax }}
+{{>partial this}}
+
+{{! using the module lookup syntax ('$') }}
+{{$title title}}
+
+{{! using the relative lookup syntax}}
+{{description description}}
+
+{{image "images/path/to/image"}}


### PR DESCRIPTION
Encountered an issue where compilation would fail if the template contained a partial and the `inlineRequires` options was used.

In my case I had something like:

```hbs
{{> partial }}
<img src="img/connection.svg">
```

My `module.loaders` conf was:

```js
{
  test: /\.hbs$/,
  loader: 'handlebars?inlineRequires=img/'
},
{
  test: /\.svg$/,
  loader: 'file?name=img/[hash].[ext]!svgo'
}
```

Which resulted in:

```
Module build failed: TypeError: undefined is not a function
```

Not sure if this is your preferred way of fixing this, but I've added a new test so you can hopefully see what's going on.