### PR TITLE
Allow knownHelpers to be seeded manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following query options are supported:
  - *extensions*: Searches for templates with alternate extensions. Defaults are .handlebars, .hbs, and '' (no extension).
  - *inlineRequires*: Defines a regex that identifies strings within helper/partial parameters that should be replaced by inline require statements.
  - *rootRelative*: When automatically resolving partials and helpers, use an implied root path if none is present. Default = `./`. Setting this to be empty effectively turns off automatically resolving relative handlebars resources for items like `{{helper}}`. `{{./helper}}` will still resolve as expected.
+ - *knownHelpers*: Array of helpers that are registered at runtime and should not explicitly be required by webpack. This helps with interoperability for libraries like Thorax [helpers](http://thoraxjs.org/api.html#template-helpers).
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function(source) {
 		inlineRequires = new RegExp(inlineRequires);
 	}
 
-	var debug = false;
+	var debug = query.debug;
 
 	var hb = handlebars.create();
 	var JavaScriptCompiler = hb.JavaScriptCompiler;

--- a/index.js
+++ b/index.js
@@ -41,10 +41,7 @@ module.exports = function(source) {
 
 	var queryKnownHelpers = query.knownHelpers;
 	if (queryKnownHelpers) {
-		if (!Array.isArray(queryKnownHelpers)) {
-			queryKnownHelpers = [queryKnownHelpers];
-		}
-		queryKnownHelpers.forEach(function(k) {
+		[].concat(queryKnownHelpers).forEach(function(k) {
 			knownHelpers[k] = true;
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -39,6 +39,16 @@ module.exports = function(source) {
 	var foundUnclearStuff = {};
 	var knownHelpers = {};
 
+	var queryKnownHelpers = query.knownHelpers;
+	if (queryKnownHelpers) {
+		if (!Array.isArray(queryKnownHelpers)) {
+			queryKnownHelpers = [queryKnownHelpers];
+		}
+		queryKnownHelpers.forEach(function(k) {
+			knownHelpers[k] = true;
+		});
+	}
+
 	var inlineRequires = query.inlineRequires;
 	if (inlineRequires) {
 		inlineRequires = new RegExp(inlineRequires);

--- a/test/with-known-helpers.handlebars
+++ b/test/with-known-helpers.handlebars
@@ -1,0 +1,3 @@
+{{someKnownHelper data}}
+
+<div></div>


### PR DESCRIPTION
This should solve #17 and #25 in a general fashion as suggested by @diurnalist in #17:
> Add another option, `knownHelpers` that is an array of strings you can provide, which is the list of helpers you will allow to 'pass through' (will not be explicitly required by webpack) if they are found.

: )
