### PR TITLE
Check that appendToBuffer is called with string

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = function(source) {
 		};
 		MyJavaScriptCompiler.prototype.appendToBuffer = function (str) {
 			// This is a template (stringified HTML) chunk
-			if (str.indexOf('"') === 0) {
+			if (typeof str === "string" && str.indexOf('"') === 0) {
 				var replacements = findNestedRequires(str, inlineRequires);
 				str = fastreplace(str, replacements, function (match) {
 					return "\" + require(" + JSON.stringify(match) + ") + \"";


### PR DESCRIPTION
When upgrading from `handlebars@1.3.0` to `handlebars@3.0.3`, everything started to break for me. Sticking a `console.log(str)` into `MyJavaScriptCompiler.prototype.appendToBuffer` showed that `str` was sometimes an `object` (example of the object found underneath).

Putting in this simple check that `str` is indeed a `string` fixed it for me, and everything works beautifully.

If this check is _not_ needed, could you point me to where I can start digging in my code to find the error?

```js
{ children: 
   [ { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true },
     { children: [Object],
       sourceContents: {},
       line: 1,
       column: 0,
       source: null,
       name: null,
       '$$$isSourceNode$$$': true } ],
  sourceContents: {},
  line: 1,
  column: 0,
  source: null,
  name: null,
  '$$$isSourceNode$$$': true }
```