### PR TITLE
Allow Handlebars 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "loader-utils": "0.2.x"
   },
   "peerDependencies": {
-    "handlebars": ">= 1.3.0 < 4"
+    "handlebars": ">= 1.3.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
Handlebars 4 is out. Tests pass. Loader can support it.